### PR TITLE
Fixed typo in consume-stream example

### DIFF
--- a/examples/consume-stream.php
+++ b/examples/consume-stream.php
@@ -61,7 +61,7 @@ class EventHandler implements DataSift_IStreamConsumerEventHandler
 	 */
 	public function onInteraction($consumer, $interaction, $hash)
 	{
-		if (!isset($interaction['interation']['content'])) {
+		if (!isset($interaction['interaction']['content'])) {
 			$interaction['interaction']['content'] = 'No interaction.content for this interaction';
 		}
 		echo $hash.': '.$interaction['interaction']['content'].PHP_EOL.'--'.PHP_EOL;


### PR DESCRIPTION
Changed
 $interaction['interation']['content']
to
 $interaction['interaction']['content']
